### PR TITLE
Fix special type quoting to match TOON spec

### DIFF
--- a/Sources/TOONEncoder/TOONEncoder.swift
+++ b/Sources/TOONEncoder/TOONEncoder.swift
@@ -517,15 +517,12 @@ public final class TOONEncoder {
             let iso8601 = ISO8601DateFormatter()
             iso8601.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             let dateString = iso8601.string(from: date)
-            // Dates are quoted in objects, unquoted at root
-            return inObject ? "\"\(dateString)\"" : dateString
+            return encodeStringLiteral(dateString, delimiter: delimiter)
         case .url(let url):
-            // URLs are never quoted
-            return url.absoluteString
+            return encodeStringLiteral(url.absoluteString, delimiter: delimiter)
         case .data(let data):
             let base64 = data.base64EncodedString()
-            // Data is quoted in objects, unquoted at root
-            return inObject ? "\"\(base64)\"" : base64
+            return encodeStringLiteral(base64, delimiter: delimiter)
         case .array, .object:
             return nil
         }

--- a/Tests/TOONEncoderTests/TOONEncoderTests.swift
+++ b/Tests/TOONEncoderTests/TOONEncoderTests.swift
@@ -1222,7 +1222,7 @@ struct TOONEncoderTests {
     @Test func dateConversion() async throws {
         let date = Date(timeIntervalSince1970: 0)
         let dateResult = String(data: try encoder.encode(date), encoding: .utf8)!
-        #expect(dateResult.contains("1970-01-01T00:00:00.000Z"))
+        #expect(dateResult.contains("\"1970-01-01T00:00:00.000Z\""))
 
         struct DateObject: Codable {
             let created: Date
@@ -1236,7 +1236,7 @@ struct TOONEncoderTests {
     @Test func urlConversion() async throws {
         let url = URL(string: "https://example.com")!
         let urlResult = String(data: try encoder.encode(url), encoding: .utf8)!
-        #expect(urlResult.contains("https://example.com"))
+        #expect(urlResult.contains("\"https://example.com\""))
 
         struct URLObject: Codable {
             let url: URL
@@ -1244,7 +1244,7 @@ struct TOONEncoderTests {
 
         let urlObj = URLObject(url: url)
         let urlObjResult = String(data: try encoder.encode(urlObj), encoding: .utf8)!
-        #expect(urlObjResult.contains("url: https://example.com"))
+        #expect(urlObjResult.contains("url: \"https://example.com\""))
     }
 
     @Test func dataConversion() async throws {
@@ -1258,7 +1258,7 @@ struct TOONEncoderTests {
 
         let dataObj = DataObject(data: data)
         let dataObjResult = String(data: try encoder.encode(dataObj), encoding: .utf8)!
-        #expect(dataObjResult.contains("data: \"aGVsbG8=\""))
+        #expect(dataObjResult.contains("data: aGVsbG8="))
     }
 
     @Test func nonFiniteNumbers() async throws {


### PR DESCRIPTION
This PR updates encoding of `Date`, `URL`, and `Data` types to follow the same string quoting rules as the TypeScript reference implementation.

**Before:**

- `Date`: Unquoted at root, quoted in objects
- `URL`: Never quoted
- `Data`: Unquoted at root, quoted in objects

**After:**

All three types now pass through `encodeStringLiteral()` with delimiter-aware quoting rules